### PR TITLE
Amahi 8

### DIFF
--- a/app/views/disk_wizard/select_device.html.erb
+++ b/app/views/disk_wizard/select_device.html.erb
@@ -5,7 +5,7 @@
 
     function getDevices() {
         $.ajax({
-            url: "/tab/disks/disk_wizard/get_all_devices",
+            url: '<%= disk_wizards_engine.get_all_devices_path%>',
             async: true,
             dataType: 'script',
             type: "GET",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ DiskWizards::Engine.routes.draw do
 # root 'welcome#index'
 # root :to =>  "welcome#index"
 # scope 'tab/' do
-root :to => 'disk_wizards#select_device'
+  root :to => 'disk_wizard#select_device'
   get "get_all_devices" => 'disk_service#get_all_devices'
   get "check_label" => 'disk_service#check_label'
   get 'debug_info' => 'disk_service#debug_info'

--- a/lib/command_executor.rb
+++ b/lib/command_executor.rb
@@ -55,7 +55,7 @@ class CommandExecutor
   # Execute the command with assigned parameters when initializing the object
   # == Parameters:
   #     blocking is true  =~ Command.run_now or blocking is not true  =~ command.execute
-  def execute blocking = false, debug = @@debug_mode
+  def execute blocking = true, debug = @@debug_mode
     #If user select debug mode
     #1. push current command(command name and parameters) to `operations_log` array, where it will be used to list all the operations took place during the debug mode
     #2. Return from the method immediately,to prevent executing further
@@ -76,7 +76,7 @@ class CommandExecutor
     begin
       if blocking
         Open3.popen3("sudo", "./dsk-wz.sh", @command, @parameters, :chdir => script_location) do |stdin, stdout, stderr, wait_thr|
-          @stdout = stdout; @stderr = stderr; @wait_thr = wait_thr
+          @stdout = stdout.read; @stderr = stderr.read; @wait_thr = wait_thr.value
         end
       else
         _, @stdout, @stderr, @wait_thr = Open3.popen3("sudo", "./dsk-wz.sh", @command, @parameters, :chdir => script_location)
@@ -85,10 +85,10 @@ class CommandExecutor
       @success = false
       raise error
     end
-    @exit_status = @wait_thr.value.exitstatus
+    @exit_status = @wait_thr.exitstatus
     @pid = @wait_thr.pid
-    @result = @stdout.read
-    @success = @wait_thr.value.success?
+    @result = @stdout
+    @success = @wait_thr.success?
   end
 
   def success?

--- a/lib/disk_utils.rb
+++ b/lib/disk_utils.rb
@@ -99,7 +99,7 @@ class DiskUtils
         params = " info  --query=property --name=#{kname}"
       end
       udevadm = CommandExecutor.new command, params
-      udevadm.execute false, false # None blocking and not debug mode
+      udevadm.execute #false, false # None blocking and not debug mode
       raise "Command execution error: #{udevadm.stderr.read}" if not udevadm.success?
       udevadm.result.each_line do |line|
         line.squish!
@@ -117,7 +117,7 @@ class DiskUtils
       end
 
       df = CommandExecutor.new command, params
-      df.execute false, false # None blocking and not debug mode
+      df.execute #false, false # None blocking and not debug mode
       raise "Command execution error: #{df.stderr.read}" if not df.success?
       line = df.result.lines.pop
       line.gsub!(/"/, '')
@@ -132,7 +132,7 @@ class DiskUtils
         params = "-sm /dev/#{kname} unit b  print free" # Use parted machine parseable output,independent from O/S language -s for --script and -m for --machine
       end
       parted = CommandExecutor.new command, params
-      parted.execute false, false # None blocking and not debug mode
+      parted.execute #false, false # None blocking and not debug mode
       return false if not parted.success?
 
       # REFERENCE: http://lists.alioth.debian.org/pipermail/parted-devel/2006-December/000573.html
@@ -241,7 +241,7 @@ class DiskUtils
       commands.each do |command, args|
         executor = CommandExecutor.new(command, args)
         executor.execute()
-        DebugLogger.info "Command execution error: #{executor.stderr.read}" if not executor.success? # Suppress warnings and errors,don't re-raise the exception.only do notify the kernel,Warnings and errors are out of the DW scope
+        raise "Command execution error: #{executor.stderr}" if not executor.success? # Suppress warnings and errors,don't re-raise the exception.only do notify the kernel,Warnings and errors are out of the DW scope
       end
     end
 
@@ -321,7 +321,7 @@ class DiskUtils
       multipath = CommandExecutor.new command, params
       if which command
         multipath.execute
-        raise "Command execution error: #{multipath.stderr.read}" if not multipath.success?
+        raise "Command execution error: #{multipath.stderr}" if not multipath.success?
       else
         return false
       end

--- a/lib/disk_utils.rb
+++ b/lib/disk_utils.rb
@@ -30,8 +30,8 @@ class DiskUtils
       lsblk = CommandExecutor.new command, params
       lsblk.execute
       raise "Command execution error: #{lsblk.stderr.read}" if not lsblk.success?
-
-      lsblk.result.each_line do |line|
+      lsblk.result.each_line.with_index do |line, idx|
+        next if idx == 0
         data_hash = {}
         line.squish!
         line_data = line.gsub!(/"(.*?)"/, '\1#').split "#"

--- a/vendor/bash/dsk-wz.sh
+++ b/vendor/bash/dsk-wz.sh
@@ -51,8 +51,10 @@ fdisk)
 	executor $command $arguments;
 ;;
 *)
+	executor $command $arguments;
 	# if a command is not one we know, we exit with an error
 	echo "Sorry, command $command is not known";
-	exit -1;
+	exit 1;
 ;;
 esac
+exit 1;


### PR DESCRIPTION
that's solve three problem in three different layers
at  `dsk-wz.sh` script layer
- the script returns "-1" if the command not one of 4 special command
  at `command_execute` layer
  using non-block style of `Open3.popen3()` caused that after the thread dead the IO sockets will be closed and we cannot see the output of them
  at `all_devices` func in `disk_utils.rb` file we have to skip the first line of the output of `lsblk` command because it the header of the ouptut not an actual device or partition 
  it's a prototype to describe the problem and discuss to reach a good solution 
